### PR TITLE
base: add silent server boot profile (systemd-boot + TPM 2.0)

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -8,8 +8,9 @@ Core scripts for installing and configuring a security-hardened Arch Linux syste
 
 | Script | Purpose |
 |--------|---------|
-| `archinstall.sh` | Bare-metal installer — LVM on LUKS1, UEFI, optional TPM2 |
+| `archinstall.sh` | Bare-metal installer — LVM on LUKS1, UEFI, optional TPM2, desktop/server profile |
 | `chroot.sh` | Bare-metal post-install — system hardening inside chroot |
+| `systemd-boot.sh` | Server profile helper — bootctl install + TPM 2.0 enrollment + crypttab.initramfs |
 | `vps-install.sh` | VPS/cloud installer — single partition, swap file, BIOS/UEFI |
 | `vps-chroot.sh` | VPS post-install — same hardening adapted for VPS |
 | `vps-harden.sh` | VPS live hardening — filesystem mounts on a running system |
@@ -64,6 +65,7 @@ Core scripts for installing and configuring a security-hardened Arch Linux syste
    - LUKS encryption passphrase
    - TPM2 binding (if hardware is detected)
    - Sysctl profile (`security`, `security+performance`, or `full-performance`)
+   - Boot profile (`desktop` = GRUB + passphrase, `server` = systemd-boot + TPM 2.0 silent unlock)
 
 5. After partitioning and pacstrap, the script copies `chroot.sh` plus the selected sysctl helper/profile into the new system and enters chroot automatically.
 
@@ -251,6 +253,58 @@ sudo ./secureBoot.sh
 - Signs EFI binaries (GRUB, kernel, etc.)
 - Enrolls keys into UEFI firmware
 - Supports `-d` (key directory), `-p` (EFI mount), `-k` (key size), `-v` (validity days)
+
+---
+
+## Server Boot Profile (systemd-boot + TPM 2.0)
+
+When `archinstall.sh` prompts for boot profile, pick **`server`** to install a fully unattended boot path:
+
+- **No bootloader prompt.** GRUB is not installed; systemd-boot loads the kernel directly from the unencrypted ESP.
+- **No LUKS passphrase prompt.** A TPM 2.0–sealed key unlocks the root volume silently, bound to PCRs 0+7 (UEFI firmware state + Secure Boot state).
+- **Recovery passphrase keyslot** remains as the manual fallback when the TPM seal becomes invalid (e.g., after a firmware update or hardware change).
+
+Intended for headless boxes that must come back online after `sudo reboot` without a human at the console.
+
+### What the server profile changes vs the desktop profile
+
+| | Desktop (default) | Server |
+|---|---|---|
+| Bootloader | GRUB (`pacman -S grub`) | systemd-boot (`bootctl install`) |
+| LUKS unlock at boot | Interactive passphrase prompt | TPM 2.0 sealed key (silent) |
+| initramfs hooks | `udev + encrypt + keymap` (or `sd-encrypt` if TPM2 enabled) | `systemd + sd-encrypt + sd-vconsole` |
+| `/etc/crypttab.initramfs` | absent | `<lvm> UUID=<luks-uuid> - tpm2-device=auto` |
+| Kernel cmdline shape | `cryptdevice=…cryptkey=rootfs:/etc/luksKeys/boot.key` | `rd.luks.name=<uuid>=<lvm> rd.luks.options=tpm2-device=auto` |
+| Kernel + initramfs location | `/boot/` (inside LUKS) | `/efi/EFI/Linux/` (on the ESP) |
+| `/efi` free space required | ~50 MiB | ~250 MiB (kernel + initramfs + microcode) |
+
+The kernel-hardening cmdline flags (`slab_nomerge`, `init_on_alloc=1`, `pti=on`, etc.) and sysctl profile choice are identical across both profiles.
+
+### Hard prerequisites for the server profile
+
+- TPM 2.0 hardware detected at install time (`/sys/class/tpm/tpm0/tpm_version_major == 2`). Without it, `archinstall.sh` automatically falls back to desktop with a warning.
+- `systemd ≥ 252` (ships `systemd-cryptenroll --tpm2-device=auto`).
+- `/efi` partition with at least 500 MiB free.
+
+### What survives + what to keep off-host
+
+After installation, the LUKS header carries multiple keyslots:
+
+- **Recovery passphrase** — entered during `archinstall.sh`. Write it down off the host (paper, password manager, USB). This is your only way back in if both the TPM seal breaks **and** the boot.key file is lost.
+- **`/etc/luksKeys/boot.key`** — random keyfile seeded pre-chroot. Used to authorize the TPM enrollment during install. **Back it up off-host** (e.g., `sudo cat /etc/luksKeys/boot.key | …` to a USB drive), then optionally remove it after a confirmed silent boot.
+- **TPM-sealed slot** — the everyday auto-unlock keyslot. Regenerated on demand if PCRs change:
+
+  ```bash
+  sudo systemd-cryptenroll --wipe-slot=tpm2 /dev/<luks-part>
+  sudo systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=0+7 \
+      --unlock-key-file=/etc/luksKeys/boot.key /dev/<luks-part>
+  ```
+
+### Caveats
+
+- Firmware updates that change measured PCRs 0 or 7 invalidate the TPM seal; the next boot will fall through to the passphrase prompt. Re-enroll with the command above after the new firmware is stable.
+- Toggling Secure Boot on or off after install also invalidates the seal (PCR 7 changes).
+- The server profile does not enable Secure Boot itself — pair it with `secureBoot.sh` if you want signed-binary verification on top of the silent-unlock path.
 
 ---
 

--- a/base/archinstall.sh
+++ b/base/archinstall.sh
@@ -170,6 +170,41 @@ describe_sysctl_profile() {
     esac
 }
 
+# Prompt user for boot profile.
+#
+# - desktop: GRUB + interactive LUKS passphrase prompt (default; what every
+#   prior version of this installer produced).
+# - server:  systemd-boot + TPM 2.0 sealed key unlock. Boot is fully silent
+#   (no GRUB password, no LUKS passphrase) when PCRs 0+7 match. A recovery
+#   passphrase keyslot remains as the fallback. Intended for headless boxes
+#   that need to come back online without a human at the console.
+#
+# The server profile requires TPM 2.0 hardware. If absent, this prompt falls
+# back to desktop with a warning so the install never silently breaks.
+ask_for_boot_profile() {
+    local choice
+    while true; do
+        echo -e "${BBlue}Select boot profile:${NC}" >&2
+        echo "1) desktop  (GRUB + interactive LUKS passphrase) [default]" >&2
+        echo "2) server   (systemd-boot + TPM 2.0 silent unlock, recovery passphrase fallback)" >&2
+        read -p "Choice [1]: " choice
+        choice="${choice:-1}"
+        case "$choice" in
+            1) echo "desktop"; return 0 ;;
+            2) echo "server";  return 0 ;;
+            *) echo -e "${BRed}Invalid choice. Please enter 1 or 2.\n${NC}" >&2 ;;
+        esac
+    done
+}
+
+describe_boot_profile() {
+    case "$1" in
+        desktop) echo "desktop (GRUB + passphrase)" ;;
+        server)  echo "server (systemd-boot + TPM 2.0 silent unlock)" ;;
+        *)       echo "$1" ;;
+    esac
+}
+
 # Prompt user for timezone
 ask_for_timezone() {
     local tz
@@ -584,15 +619,38 @@ echo -e "\n${BBlue}Kernel sysctl profile:${NC}"
 SYSCTL_PROFILE=$(ask_for_sysctl_profile)
 SYSCTL_PROFILE_LABEL=$(describe_sysctl_profile "$SYSCTL_PROFILE")
 
+echo -e "\n${BBlue}Boot profile:${NC}"
+BOOT_PROFILE=$(ask_for_boot_profile)
+BOOT_PROFILE_LABEL=$(describe_boot_profile "$BOOT_PROFILE")
+
+# Server profile presupposes a usable TPM 2.0. If the earlier TPM detection
+# failed, refuse to start the install rather than producing an unbootable box.
+if [[ "$BOOT_PROFILE" == "server" ]]; then
+    if [ "$TPM_AVAILABLE" != true ]; then
+        echo -e "${BRed}Server profile requires TPM 2.0, but no usable TPM 2.0 was detected.${NC}"
+        echo -e "${BRed}Falling back to desktop profile (GRUB + passphrase).${NC}"
+        BOOT_PROFILE="desktop"
+        BOOT_PROFILE_LABEL=$(describe_boot_profile "$BOOT_PROFILE")
+    else
+        # Server profile is silent-unlock by definition: force TPM-LUKS on,
+        # default PCRs 0+7 if the user wasn't already enrolling.
+        USE_TPM_LUKS=true
+        TPM_PCRS="${TPM_PCRS:-0+7}"
+        echo -e "${BGreen}Server profile selected — TPM 2.0 LUKS unlock enabled (PCRs: $TPM_PCRS).${NC}"
+        log_action "Server profile forced USE_TPM_LUKS=true, PCRs=$TPM_PCRS"
+    fi
+fi
+
 echo -e "\nUsername: $USERNAME"
 echo -e "Hostname: $HOSTNAME"
 echo -e "Timezone: $TIMEZONE"
 echo -e "Locale: $LOCALE"
 echo -e "Keymap: $KEYMAP"
 echo -e "Sysctl Profile: $SYSCTL_PROFILE_LABEL"
+echo -e "Boot Profile:   $BOOT_PROFILE_LABEL"
 echo -e "SSH Key:  ${SSH_PUBKEY:+(provided)}${SSH_PUBKEY:-(none)}\n"
 
-log_action "User: $USERNAME, Hostname: $HOSTNAME, Timezone: $TIMEZONE, Locale: $LOCALE, Keymap: $KEYMAP, Sysctl Profile: $SYSCTL_PROFILE_LABEL"
+log_action "User: $USERNAME, Hostname: $HOSTNAME, Timezone: $TIMEZONE, Locale: $LOCALE, Keymap: $KEYMAP, Sysctl Profile: $SYSCTL_PROFILE_LABEL, Boot Profile: $BOOT_PROFILE_LABEL"
 
 SWAP_SIZE="${SIZE_OF_SWAP}G"
 ROOT_SIZE="${SIZE_OF_ROOT}G"
@@ -791,7 +849,7 @@ pacstrap /mnt base base-devel archlinux-keyring \
     linux linux-headers \
     linux-firmware wireless-regdb intel-ucode amd-ucode \
     lvm2 cryptsetup device-mapper \
-    grub efibootmgr os-prober \
+    efibootmgr os-prober \
     networkmanager iwd dhcpcd openssh \
     iptables-nft nftables \
     apparmor audit rng-tools haveged \
@@ -810,7 +868,15 @@ pacstrap /mnt base base-devel archlinux-keyring \
     noto-fonts noto-fonts-cjk noto-fonts-emoji ttf-dejavu ttf-liberation \
     man-db man-pages texinfo
 
-# Install TPM tools if TPM is being used
+# Install bootloader package per chosen profile.
+# - desktop: GRUB (default, what the rest of chroot.sh assumes)
+# - server:  systemd-boot ships inside the systemd package, already pulled
+#            by base; no extra package needed here.
+if [[ "$BOOT_PROFILE" == "desktop" ]]; then
+    pacstrap /mnt grub
+fi
+
+# Install TPM tools if TPM is being used (always true for the server profile)
 if [ "$USE_TPM_LUKS" = true ]; then
     pacstrap /mnt tpm2-tools tpm2-tss tpm2-abrmd tpm2-pkcs11
 fi
@@ -872,6 +938,8 @@ export INSTALL_CRYPT="$CRYPT_NAME"
 export INSTALL_LVM="$LVM_NAME"
 export INSTALL_VAR_SIZE="${VAR_SIZE:-}"
 export INSTALL_TPM="$USE_TPM_LUKS"
+export INSTALL_TPM_PCRS="${TPM_PCRS:-0+7}"
+export INSTALL_BOOT_PROFILE="$BOOT_PROFILE"
 export INSTALL_SSH_PUBKEY="$SSH_PUBKEY"
 export INSTALL_SYSCTL_PROFILE="$SYSCTL_PROFILE"
 export INSTALL_TIMEZONE="$TIMEZONE"
@@ -888,6 +956,8 @@ export _INSTALL_HOST="$HOSTNAME"
 export _INSTALL_CRYPT="$CRYPT_NAME"
 export _INSTALL_LVM="$LVM_NAME"
 export INSTALL_TPM="$USE_TPM_LUKS"
+export INSTALL_TPM_PCRS="${TPM_PCRS:-0+7}"
+export INSTALL_BOOT_PROFILE="$BOOT_PROFILE"
 export _INSTALL_SSH_PUBKEY="$SSH_PUBKEY"
 export _INSTALL_SYSCTL_PROFILE="$SYSCTL_PROFILE"
 export _INSTALL_TIMEZONE="$TIMEZONE"
@@ -897,6 +967,14 @@ EOF
 
 chmod +x /mnt/set-install-vars.sh
 cp ./chroot.sh /mnt/
+
+# Server profile needs the systemd-boot helper inside the chroot to set up
+# bootctl + systemd-cryptenroll + crypttab.initramfs after the base system
+# is in place. Ship it next to chroot.sh; chroot.sh sources it on demand.
+if [[ "$BOOT_PROFILE" == "server" && -f ./systemd-boot.sh ]]; then
+    cp ./systemd-boot.sh /mnt/
+    chmod +x /mnt/systemd-boot.sh
+fi
 chmod +x /mnt/chroot.sh
 
 # Copy hardening scripts

--- a/base/chroot.sh
+++ b/base/chroot.sh
@@ -1032,18 +1032,27 @@ echo -e "${BBlue}Setting default ACLs on root and home directory${NC}"
 setfacl -d -m u::rwx,g::---,o::--- ~
 setfacl -d -m u::rwx,g::---,o::--- "/home/$USERNAME"
 
-echo -e "${BBlue}Adding GRUB package...${NC}"
-pacman -S grub efibootmgr os-prober --noconfirm
+# Boot profile branch — desktop uses GRUB (default); server uses systemd-boot
+# and is wired below after mkinitcpio finalizes HOOKS.
+if [[ "${INSTALL_BOOT_PROFILE:-desktop}" != "server" ]]; then
+    echo -e "${BBlue}Adding GRUB package...${NC}"
+    pacman -S grub efibootmgr os-prober --noconfirm
 
-# GRUB hardening setup and encryption
-echo -e "${BBlue}Adjusting /etc/mkinitcpio.conf for encryption...${NC}"
-sed -i "s|^HOOKS=.*|HOOKS=(base udev autodetect keyboard keymap modconf block encrypt lvm2 filesystems fsck)|g" /etc/mkinitcpio.conf
-sed -i "s|^FILES=.*|FILES=(${LUKS_KEYS})|g" /etc/mkinitcpio.conf
-# NOTE: mkinitcpio is called AFTER the TPM/non-TPM HOOKS are finalized below
+    # GRUB hardening setup and encryption
+    echo -e "${BBlue}Adjusting /etc/mkinitcpio.conf for encryption...${NC}"
+    sed -i "s|^HOOKS=.*|HOOKS=(base udev autodetect keyboard keymap modconf block encrypt lvm2 filesystems fsck)|g" /etc/mkinitcpio.conf
+    sed -i "s|^FILES=.*|FILES=(${LUKS_KEYS})|g" /etc/mkinitcpio.conf
+    # NOTE: mkinitcpio is called AFTER the TPM/non-TPM HOOKS are finalized below
 
-echo -e "${BBlue}Adjusting etc/default/grub for encryption...${NC}"
-sed -ri 's|^#?GRUB_PRELOAD_MODULES=.*|GRUB_PRELOAD_MODULES="part_gpt part_msdos lvm"|' /etc/default/grub
-sed -ri 's|^#?GRUB_ENABLE_CRYPTODISK=.*|GRUB_ENABLE_CRYPTODISK=y|' /etc/default/grub
+    echo -e "${BBlue}Adjusting etc/default/grub for encryption...${NC}"
+    sed -ri 's|^#?GRUB_PRELOAD_MODULES=.*|GRUB_PRELOAD_MODULES="part_gpt part_msdos lvm"|' /etc/default/grub
+    sed -ri 's|^#?GRUB_ENABLE_CRYPTODISK=.*|GRUB_ENABLE_CRYPTODISK=y|' /etc/default/grub
+else
+    echo -e "${BBlue}Boot profile: server (systemd-boot + TPM 2.0); skipping GRUB install${NC}"
+    # efibootmgr was pacstrapped by archinstall.sh in the base set; we don't
+    # need GRUB. Initial HOOKS/FILES are left untouched — the TPM-aware block
+    # below sets the final sd-encrypt HOOKS that systemd-boot.sh depends on.
+fi
 
 chmod 400 /etc/luksKeys/boot.key
 
@@ -1078,21 +1087,55 @@ fi
 echo -e "${BBlue}Generating initramfs with final HOOKS configuration...${NC}"
 mkinitcpio -P
 
-sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT=${GRUBSEC}|" /etc/default/grub
-sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=${GRUBCMD}|" /etc/default/grub
+if [[ "${INSTALL_BOOT_PROFILE:-desktop}" != "server" ]]; then
+    # Desktop profile — finalize GRUB cmdline + framebuffer.
+    sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=.*|GRUB_CMDLINE_LINUX_DEFAULT=${GRUBSEC}|" /etc/default/grub
+    sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=${GRUBCMD}|" /etc/default/grub
 
-# Force a low-res GRUB framebuffer. Without this, GRUB on some UEFI firmwares
-# falls back to a mode where the password prompt never renders (black screen
-# on boot). 1024x768 is the safest universally-supported fallback.
-if grep -q '^#\?GRUB_GFXMODE=' /etc/default/grub; then
-    sed -ri 's|^#?GRUB_GFXMODE=.*|GRUB_GFXMODE=1024x768,auto|' /etc/default/grub
+    # Force a low-res GRUB framebuffer. Without this, GRUB on some UEFI firmwares
+    # falls back to a mode where the password prompt never renders (black screen
+    # on boot). 1024x768 is the safest universally-supported fallback.
+    if grep -q '^#\?GRUB_GFXMODE=' /etc/default/grub; then
+        sed -ri 's|^#?GRUB_GFXMODE=.*|GRUB_GFXMODE=1024x768,auto|' /etc/default/grub
+    else
+        echo 'GRUB_GFXMODE=1024x768,auto' >> /etc/default/grub
+    fi
+    if grep -q '^#\?GRUB_GFXPAYLOAD_LINUX=' /etc/default/grub; then
+        sed -ri 's|^#?GRUB_GFXPAYLOAD_LINUX=.*|GRUB_GFXPAYLOAD_LINUX=keep|' /etc/default/grub
+    else
+        echo 'GRUB_GFXPAYLOAD_LINUX=keep' >> /etc/default/grub
+    fi
 else
-    echo 'GRUB_GFXMODE=1024x768,auto' >> /etc/default/grub
-fi
-if grep -q '^#\?GRUB_GFXPAYLOAD_LINUX=' /etc/default/grub; then
-    sed -ri 's|^#?GRUB_GFXPAYLOAD_LINUX=.*|GRUB_GFXPAYLOAD_LINUX=keep|' /etc/default/grub
-else
-    echo 'GRUB_GFXPAYLOAD_LINUX=keep' >> /etc/default/grub
+    # Server profile — call the systemd-boot + TPM 2.0 helper. This is the
+    # equivalent of the boot_hardening.sh phases H3 + H4 + H7 collapsed into
+    # one install-time call:
+    #   - bootctl install (UEFI Linux Boot Manager entry + ESP staging)
+    #   - kernel + initramfs + microcode → /efi/EFI/Linux/
+    #   - /efi/loader/loader.conf + entries/arch.conf with rd.luks.name
+    #     and tpm2-device=auto
+    #   - /etc/crypttab.initramfs wired for tpm2-device=auto
+    #   - mkinitcpio -P (second build, now embedding crypttab.initramfs)
+    #   - systemd-cryptenroll seals a new keyslot to TPM PCRs 0+7
+    #   - verifies the systemd-tpm2 token landed; hard-fails if not
+    #
+    # The helper script ships next to chroot.sh; archinstall.sh copies it
+    # to /systemd-boot.sh when BOOT_PROFILE=server.
+    if [[ ! -x /systemd-boot.sh ]]; then
+        echo -e "${BRed}FATAL: /systemd-boot.sh missing or not executable.${NC}" >&2
+        echo -e "${BRed}archinstall.sh did not stage it for the server profile.${NC}" >&2
+        exit 50
+    fi
+
+    # Forward the variables systemd-boot.sh expects. LUKS_UUID and LVM_NAME
+    # are already set above in the encryption section of chroot.sh.
+    LUKS_UUID="$LUKS_UUID" \
+    LVM_NAME="$LVM_NAME" \
+    LUKS_KEYS="/etc/luksKeys" \
+    INSTALL_TPM_PCRS="${INSTALL_TPM_PCRS:-0+7}" \
+    EFI_MOUNT="/efi" \
+    KERNEL_NAME="linux" \
+    KERNEL_HARDEN="${GRUBSEC//\"/}" \
+    bash /systemd-boot.sh
 fi
 
 sleep 1

--- a/base/systemd-boot.sh
+++ b/base/systemd-boot.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# base/systemd-boot.sh
+#
+# Installs systemd-boot, wires the initramfs for TPM 2.0 LUKS unlock, and
+# enrolls the TPM keyslot. Called from chroot.sh when the user picked the
+# "server" boot profile in archinstall.sh.
+#
+# End-state when this script returns 0:
+#   - systemd-boot installed at /efi/EFI/systemd/systemd-bootx64.efi
+#   - Linux Boot Manager UEFI entry created (efibootmgr) and set first
+#   - Kernel + initramfs + microcode copied to /efi/EFI/Linux/
+#   - /efi/loader/loader.conf set with default=arch.conf, timeout=3
+#   - /efi/loader/entries/arch.conf with rd.luks.name + tpm2-device=auto
+#   - /etc/crypttab.initramfs contains a single line wiring TPM unlock
+#   - LUKS volume has a new keyslot sealed to the TPM (systemd-tpm2 token)
+#
+# Safety properties:
+#   - Refuses to start if TPM 2.0 isn't enumerable, /efi is missing, or the
+#     LUKS UUID isn't present on the target disk.
+#   - Hard-fails if systemd-cryptenroll claims success but no systemd-tpm2
+#     token is found in the LUKS header afterwards (silent enrollment was
+#     the failure mode we hit on real hardware once already).
+#   - The pre-existing /etc/luksKeys/boot.key keyfile slot is left alone.
+#     It's the documented manual fallback if TPM unsealing ever fails and
+#     the recovery passphrase has also been lost. The post-install cleanup
+#     step (run-once after a confirmed silent boot) removes it.
+#
+# Inputs (env vars set by chroot.sh):
+#   LUKS_UUID       — UUID of the LUKS partition (e.g. /dev/nvme0n1p3)
+#   LVM_NAME        — LUKS-opened mapper name (e.g. lvm_arch / crypt_lvm)
+#   LUKS_KEYS       — directory containing boot.key (e.g. /etc/luksKeys)
+#   INSTALL_TPM_PCRS — PCR string (e.g. "0+7"); defaults to 0+7
+#   EFI_MOUNT       — EFI System Partition mount point (defaults /efi)
+#   KERNEL_NAME     — kernel base name (defaults "linux")
+#   KERNEL_HARDEN   — kernel cmdline hardening flags string
+
+set -euo pipefail
+
+# Color helpers — kept compatible with the parent scripts' palette so log
+# output reads consistently across archinstall.sh / chroot.sh / here.
+if [[ -t 1 ]]; then
+    BRed='\033[1;31m'; BGreen='\033[1;32m'; BYellow='\033[1;33m'
+    BBlue='\033[1;34m'; NC='\033[0m'
+else
+    BRed=''; BGreen=''; BYellow=''; BBlue=''; NC=''
+fi
+
+# Resolve config — sensible defaults so the script can also be exercised
+# stand-alone post-install for debugging.
+LUKS_UUID="${LUKS_UUID:?LUKS_UUID must be set (UUID of the LUKS partition)}"
+LVM_NAME="${LVM_NAME:?LVM_NAME must be set (LUKS mapper / VG name)}"
+LUKS_KEYS="${LUKS_KEYS:-/etc/luksKeys}"
+TPM_PCRS="${INSTALL_TPM_PCRS:-${TPM_PCRS:-0+7}}"
+EFI_MOUNT="${EFI_MOUNT:-/efi}"
+KERNEL_NAME="${KERNEL_NAME:-linux}"
+KERNEL_HARDEN="${KERNEL_HARDEN:-slab_nomerge init_on_alloc=1 init_on_free=1 page_alloc.shuffle=1 pti=on randomize_kstack_offset=on vsyscall=none quiet loglevel=3}"
+
+BOOT_KEY="$LUKS_KEYS/boot.key"
+
+banner() {
+    echo -e "\n${BBlue}========== $* ==========${NC}"
+}
+
+# -------------------------------------------------------------------------
+# Pre-flight — refuse to start if any assumption is wrong. Bricking a fresh
+# install at this point would mean re-running archinstall.sh, so guard
+# everything aggressively before any state change.
+# -------------------------------------------------------------------------
+banner "pre-flight"
+
+# TPM 2.0 must be present and version 2 (not 1.2).
+if [[ ! -e /sys/class/tpm/tpm0 ]]; then
+    echo -e "${BRed}FATAL: no TPM device under /sys/class/tpm/${NC}" >&2
+    exit 21
+fi
+TPM_MAJOR=$(cat /sys/class/tpm/tpm0/tpm_version_major 2>/dev/null || echo "")
+if [[ "$TPM_MAJOR" != "2" ]]; then
+    echo -e "${BRed}FATAL: TPM is not 2.0 (tpm_version_major=$TPM_MAJOR)${NC}" >&2
+    exit 22
+fi
+echo "  TPM 2.0 present"
+
+# systemd-cryptenroll must be available (systemd ≥ 252 ships it).
+if ! command -v systemd-cryptenroll >/dev/null 2>&1; then
+    echo -e "${BRed}FATAL: systemd-cryptenroll not found in PATH${NC}" >&2
+    exit 23
+fi
+
+# /efi must be mounted with at least 500 MB free. Kernel (~17 MB) +
+# initramfs (~110 MB) + microcode (~10 MB) + headroom for future kernels.
+if ! mountpoint -q "$EFI_MOUNT"; then
+    echo -e "${BRed}FATAL: $EFI_MOUNT is not a mountpoint${NC}" >&2
+    exit 24
+fi
+AVAIL_KB=$(df --output=avail -k "$EFI_MOUNT" | tail -1)
+if (( AVAIL_KB < 512000 )); then
+    echo -e "${BRed}FATAL: less than 500 MB free on $EFI_MOUNT ($((AVAIL_KB/1024)) MB)${NC}" >&2
+    exit 25
+fi
+echo "  $EFI_MOUNT mounted, $((AVAIL_KB/1024)) MB free"
+
+# Boot key must exist (archinstall.sh seeded it pre-chroot). It seeds the
+# TPM enrollment as the existing unlock key.
+if [[ ! -f "$BOOT_KEY" ]]; then
+    echo -e "${BRed}FATAL: $BOOT_KEY missing — archinstall.sh should have created it${NC}" >&2
+    exit 26
+fi
+
+# LUKS UUID resolvable to a real partition?
+if ! blkid -U "$LUKS_UUID" >/dev/null 2>&1; then
+    echo -e "${BRed}FATAL: no block device with LUKS UUID $LUKS_UUID${NC}" >&2
+    exit 27
+fi
+LUKS_DEV=$(blkid -U "$LUKS_UUID")
+echo "  LUKS device: $LUKS_DEV"
+
+# -------------------------------------------------------------------------
+# bootctl install — writes systemd-boot binaries to /efi and registers the
+# UEFI variable. Without --no-variables (which we used during the live
+# migration), the firmware boot entry gets created in one shot.
+# -------------------------------------------------------------------------
+banner "bootctl install"
+bootctl install
+echo
+
+# -------------------------------------------------------------------------
+# Copy kernel + initramfs + microcode to /efi/EFI/Linux/
+# systemd-boot reads them from there at boot time. /boot lives inside the
+# encrypted LVM, but /efi is unencrypted FAT32 — that's the whole reason
+# systemd-boot can chain-load without prompting.
+# -------------------------------------------------------------------------
+banner "stage kernel + initramfs + microcode to $EFI_MOUNT/EFI/Linux/"
+mkdir -p "$EFI_MOUNT/EFI/Linux"
+
+for f in "/boot/vmlinuz-$KERNEL_NAME" "/boot/initramfs-$KERNEL_NAME.img"; do
+    if [[ ! -s "$f" ]]; then
+        echo -e "${BRed}FATAL: missing or empty kernel artifact: $f${NC}" >&2
+        exit 30
+    fi
+    cp -v "$f" "$EFI_MOUNT/EFI/Linux/"
+done
+
+# Microcode is optional — depends on which ucode package matches the CPU.
+# Copy whichever is present; absence is not an error.
+for ucode in /boot/intel-ucode.img /boot/amd-ucode.img; do
+    [[ -f "$ucode" ]] && cp -v "$ucode" "$EFI_MOUNT/EFI/Linux/"
+done
+
+# -------------------------------------------------------------------------
+# loader.conf — defaults shown to the user during boot
+# -------------------------------------------------------------------------
+banner "write $EFI_MOUNT/loader/loader.conf"
+cat > "$EFI_MOUNT/loader/loader.conf" <<EOF
+default arch.conf
+timeout 3
+console-mode max
+editor no
+EOF
+cat "$EFI_MOUNT/loader/loader.conf"
+
+# -------------------------------------------------------------------------
+# arch.conf — the actual boot entry
+# - rd.luks.name pins the LUKS UUID to a mapper name
+# - rd.luks.options=tpm2-device=auto tells sd-encrypt to use the TPM token
+# - root= mounts the LV that's inside the unlocked LUKS
+# - KERNEL_HARDEN are the same flags the desktop GRUB path already sets
+# -------------------------------------------------------------------------
+banner "write $EFI_MOUNT/loader/entries/arch.conf"
+{
+    echo "title   Arch Linux"
+    echo "linux   /EFI/Linux/vmlinuz-$KERNEL_NAME"
+    for ucode in intel-ucode.img amd-ucode.img; do
+        [[ -f "$EFI_MOUNT/EFI/Linux/$ucode" ]] && echo "initrd  /EFI/Linux/$ucode"
+    done
+    echo "initrd  /EFI/Linux/initramfs-$KERNEL_NAME.img"
+    echo "options rd.luks.name=$LUKS_UUID=$LVM_NAME rd.luks.options=tpm2-device=auto root=/dev/mapper/${LVM_NAME}-root rw $KERNEL_HARDEN"
+} > "$EFI_MOUNT/loader/entries/arch.conf"
+cat "$EFI_MOUNT/loader/entries/arch.conf"
+
+# -------------------------------------------------------------------------
+# /etc/crypttab.initramfs
+# sd-encrypt reads it at boot. The "-" means no password file; tpm2-device=auto
+# tells systemd-cryptsetup to ask the TPM to release the sealed key.
+# -------------------------------------------------------------------------
+banner "write /etc/crypttab.initramfs"
+echo "$LVM_NAME UUID=$LUKS_UUID - tpm2-device=auto" > /etc/crypttab.initramfs
+cat /etc/crypttab.initramfs
+
+# -------------------------------------------------------------------------
+# Regenerate initramfs with the new crypttab embedded, then re-stage to /efi
+# -------------------------------------------------------------------------
+banner "regenerate initramfs"
+mkinitcpio -P
+cp -v "/boot/initramfs-$KERNEL_NAME.img" "$EFI_MOUNT/EFI/Linux/"
+
+# -------------------------------------------------------------------------
+# Enroll the TPM keyslot
+# - --tpm2-pcrs binds the unlock policy to PCRs 0+7 by default (UEFI
+#   firmware + Secure Boot state). Survives kernel updates.
+# - --unlock-key-file uses the boot.key seeded pre-chroot to authorize the
+#   slot creation — no interactive passphrase prompt here.
+# -------------------------------------------------------------------------
+banner "enroll TPM 2.0 keyslot (PCRs: $TPM_PCRS)"
+systemd-cryptenroll \
+    --tpm2-device=auto \
+    --tpm2-pcrs="$TPM_PCRS" \
+    --unlock-key-file="$BOOT_KEY" \
+    "$LUKS_DEV"
+
+# Verify the token landed — silent enrollment failure is the precise bug
+# that bit us during live migration. Hard-abort if no systemd-tpm2 token
+# shows up in the LUKS header.
+if ! cryptsetup luksDump "$LUKS_DEV" | grep -q "systemd-tpm2"; then
+    echo -e "${BRed}FATAL: enrollment returned 0 but no systemd-tpm2 token in LUKS header${NC}" >&2
+    echo "Inspect with: cryptsetup luksDump $LUKS_DEV" >&2
+    exit 32
+fi
+echo -e "${BGreen}[verify] systemd-tpm2 token present${NC}"
+
+# -------------------------------------------------------------------------
+# Final sanity: all the boot-critical artifacts must exist with non-zero
+# size. /efi entries dated from this run.
+# -------------------------------------------------------------------------
+banner "final verification"
+for f in \
+    "$EFI_MOUNT/EFI/systemd/systemd-bootx64.efi" \
+    "$EFI_MOUNT/EFI/Linux/vmlinuz-$KERNEL_NAME" \
+    "$EFI_MOUNT/EFI/Linux/initramfs-$KERNEL_NAME.img" \
+    "$EFI_MOUNT/loader/loader.conf" \
+    "$EFI_MOUNT/loader/entries/arch.conf" \
+    "/etc/crypttab.initramfs"
+do
+    if [[ ! -s "$f" ]]; then
+        echo -e "${BRed}FATAL: expected artifact missing or empty: $f${NC}" >&2
+        exit 33
+    fi
+    echo "  [ok] $f ($(stat -c%s "$f") bytes)"
+done
+
+cat <<EOF
+
+${BGreen}systemd-boot + TPM 2.0 server profile install complete.${NC}
+
+  Boot loader: systemd-boot
+  LUKS unlock: TPM 2.0 (PCRs $TPM_PCRS) — silent at boot when PCRs match
+  Fallback:    interactive passphrase prompt (uses your install passphrase
+               OR the recovery key in $LUKS_KEYS/boot.key)
+
+On first boot, the firmware will pick "Linux Boot Manager", systemd-boot
+will load /EFI/Linux/vmlinuz-$KERNEL_NAME, sd-encrypt will read the
+embedded /etc/crypttab.initramfs, the kernel will ask the TPM to unseal
+the keyslot, and LUKS will open with zero prompts.
+
+If a firmware update changes PCRs 0 or 7, the TPM seal becomes invalid
+and the boot falls through to the recovery passphrase prompt. To re-arm
+TPM unlock after such an event, run as root inside the booted system:
+
+    systemd-cryptenroll --wipe-slot=tpm2 $LUKS_DEV
+    systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=$TPM_PCRS \\
+        --unlock-key-file=$BOOT_KEY $LUKS_DEV
+
+EOF


### PR DESCRIPTION
## Summary

Adds a new boot-profile prompt to `archinstall.sh`:

- **desktop** (default) — existing GRUB + interactive LUKS passphrase path, untouched
- **server** — systemd-boot + TPM 2.0 sealed key, silent unattended boot

Intended for headless boxes that need to come back online after `sudo reboot` without a human at the firmware/LUKS prompt. Mirrors the end-state of a proven live-migration on real hardware.

## Files changed

- `base/archinstall.sh` — new `ask_for_boot_profile()` prompt, server profile forces `USE_TPM_LUKS=true`, pacstrap conditionally skips `grub`, `INSTALL_BOOT_PROFILE` exported to chroot, `systemd-boot.sh` staged to `/mnt/` when profile=server
- `base/chroot.sh` — GRUB install + cryptodisk config + cmdline finalization wrapped in `desktop` branch; `server` branch invokes the new helper
- `base/systemd-boot.sh` *(new)* — bootctl install, kernel/initramfs/microcode → `/efi/EFI/Linux/`, `loader.conf` + `arch.conf` with `rd.luks.name` + `tpm2-device=auto`, `/etc/crypttab.initramfs`, mkinitcpio regen, `systemd-cryptenroll --tpm2-pcrs=0+7`, verifies `systemd-tpm2` token in LUKS header (hard-fail exit 32 if absent)
- `base/README.md` — server profile section: what it changes vs desktop, hard prerequisites, recovery posture, re-enrollment recipe for firmware-update PCR changes

## Safety properties carried in

- Pre-flight: refuses server profile if `/sys/class/tpm/tpm0/tpm_version_major != 2`; `archinstall.sh` auto-falls back to desktop with a warning
- `/efi` must have ≥ 500 MiB free (kernel ~17 MB + initramfs ~110 MB + microcode + headroom)
- Hard-fails if `systemd-cryptenroll` returns 0 but no `systemd-tpm2` token lands — the specific silent-failure mode that bit us during field testing
- `/etc/luksKeys/boot.key` keyfile slot preserved through install; documented as manual fallback alongside the recovery passphrase
- Existing TPM-aware `sd-encrypt` HOOKS branch (lines 1065–1075 of chroot.sh) is reused as-is; server profile just forces `USE_TPM_LUKS=true` so the right HOOKS land

## What the resulting boot path looks like

```
UEFI firmware
  → Linux Boot Manager (Boot####, set first by bootctl install)
  → systemd-boot reads /efi/loader/entries/arch.conf
  → loads /EFI/Linux/vmlinuz-linux + initramfs-linux.img
  → sd-encrypt reads embedded /etc/crypttab.initramfs
  → systemd-cryptsetup asks TPM 2.0 to unseal keyslot bound to PCRs 0+7
  → LUKS unlocks silently, LVM activates, root mounts
  → login prompt (zero passphrase prompts on the boot path)
```

## Test plan

- [ ] `bash -n` on `archinstall.sh`, `chroot.sh`, `systemd-boot.sh` (clean locally)
- [ ] Fresh install on a QEMU VM with TPM 2.0 emulation (`swtpm`) picking the **server** profile — confirms install path
- [ ] First reboot via Linux Boot Manager — confirms zero prompts, login appears
- [ ] `bootctl status` shows `Current Boot Loader: systemd-boot`
- [ ] `cryptsetup luksDump /dev/<luks-part>` shows a `systemd-tpm2` token with `tpm2-hash-pcrs: 0+7`, `sha256` PCR bank
- [ ] Fresh install picking **desktop** profile (no TPM-required) — confirms regression: GRUB + passphrase path unchanged
- [ ] Fresh install on a VM without TPM emulation, picking **server** → confirms auto-fallback to desktop with warning

## Caveats noted in README

- Firmware updates that change PCRs 0 or 7 invalidate the TPM seal; next boot drops to passphrase. Re-enroll with the recipe in the README.
- Toggling Secure Boot on/off after install also invalidates the seal (PCR 7).
- This PR does not enable Secure Boot signing itself — pair with `secureBoot.sh` if you want signed-binary verification on top of silent unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)